### PR TITLE
Fixes for blocking call warning errors

### DIFF
--- a/custom_components/kevo_plus/manifest.json
+++ b/custom_components/kevo_plus/manifest.json
@@ -9,7 +9,7 @@
     "dcmeglio"
   ],
   "requirements": [
-    "aiokevoplus==4.3.0"
+    "aiokevoplus==4.4.0"
   ],
   "version": "1.4.0",
   "iot_class": "cloud_push"


### PR DESCRIPTION
I _think_ this (along with associated PR on the https://github.com/dcmeglio/pykevoplus dependency) may fix the various blocking call warning errors being produced.